### PR TITLE
avoiding compiler-specific types like `__int64`

### DIFF
--- a/src/musyx.c
+++ b/src/musyx.c
@@ -718,7 +718,7 @@ static void mix_voice_samples(struct hle_t* hle, musyx_t *musyx,
     for (i = 0; i < SUBFRAME_SIZE; ++i) {
         /* update sample and lut pointers and then pitch_accu */
         const int16_t *lut = (RESAMPLE_LUT + ((pitch_accu & 0xfc00) >> 8));
-        __int64 dist;
+        int64_t dist;
         int16_t v;
 
         sample += (pitch_accu >> 16);


### PR DESCRIPTION
Shouldn't it just be `int64_t` since we already have `<stdint.h>` included here?

Type names like `__int64` are Microsoft-exclusive and not supported on other compilers.  As the upstream Mupen64Plus RSP HLE has carefully maintained portability to other compilers, it wouldn't make sense to introduce a subtle conflict from a little change like this into `__int64`.
